### PR TITLE
[WISE-320] Externalize wise core version in testsuite

### DIFF
--- a/integration-testsuite/pom.xml
+++ b/integration-testsuite/pom.xml
@@ -32,6 +32,10 @@
 			<module>common</module>
     </modules>
 
+	<properties>
+		<version.wise.core>${project.version}</version.wise.core>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>junit</groupId>
@@ -51,7 +55,7 @@
 		<dependency>
 			<groupId>org.jboss.wise</groupId>
 			<artifactId>wise-core</artifactId>
-			<version>${project.version}</version>
+			<version>${version.wise.core}</version>
 		</dependency>
 
 		<dependency>
@@ -220,7 +224,7 @@
 				<dependency>
 					<groupId>org.jboss.wise</groupId>
 					<artifactId>wise-core-cxf</artifactId>
-					<version>${project.version}</version>
+					<version>${version.wise.core}</version>
 					<scope>runtime</scope> <!-- runtime scope to avoid having the dependency while compiling -->
 				</dependency>
 			</dependencies>


### PR DESCRIPTION
https://issues.jboss.org/browse/WISE-320

Now I can specify wise core version from command line, e.g. `-Dversion.wise.core=2.1.0.Final`