### PR TITLE
[WISE-318] Fix package to path conversion on Windows

### DIFF
--- a/core/src/main/java/org/jboss/wise/core/consumer/WSConsumer.java
+++ b/core/src/main/java/org/jboss/wise/core/consumer/WSConsumer.java
@@ -89,7 +89,7 @@ public abstract class WSConsumer {
             }
         };
         File scanDir = new File(new StringBuilder(outputDir.getAbsolutePath()).append(File.separator)
-                .append(targetPackage.replaceAll("\\.", File.separator)).append(File.separator).toString());
+                .append(targetPackage.replace(".", File.separator)).append(File.separator).toString());
         String[] children = scanDir.list(filter);
         if (children != null) {
             for (int i = 0; i < children.length; i++) {


### PR DESCRIPTION
Use String.replace() (ie. no regex) instead of String.replaceAll() so that we don't have to escape File.separator on Windows. This fixes failing test on Windows WSConsumerTest.parseHelloGreetingWSDLShouldFailWithPackageAndNoBindingsForNameDuplication 